### PR TITLE
Change Password Modal Update & Dropdown Menu fix

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -32,12 +32,14 @@ const signInFailure = () => {
 }
 
 const changePasswordSuccess = () => {
-  $('#modal-alert-message').html('Password Change Successful!')
+  $('#changePasswordModal').modal('hide')
+  toastr.success('Change Password Success!')
   $('form').trigger('reset')
 }
 
 const changePasswordFailure = () => {
-  $('#modal-alert-message').html('Error Changing Password. Please try again.')
+  $('#changePasswordModal').modal('hide')
+  toastr.error('Change Password Not Successful!')
   $('form').trigger('reset')
 }
 

--- a/assets/styles/_header.scss
+++ b/assets/styles/_header.scss
@@ -8,7 +8,7 @@
 
   // adjust dropdown menu so it doesn't extend off screen
   .dropdown-menu {
-    margin-left: -250%;
+    margin-left: -90px;
     position: absolute;
   }
 


### PR DESCRIPTION
Change password modal close on success & error
Toaster now display the success & error messages for change password
Fixed the dropdown menu where it display in middle of page